### PR TITLE
Use correct apt repository name

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: centos-7.0
-  - name: debian-7.7
+  - name: debian-7.8
   - name: fedora-20
   - name: macosx-10.10
     driver:

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -1,4 +1,4 @@
-apt_repository 'chrome' do
+apt_repository 'google-chrome' do
   uri node['chrome']['apt_uri']
   distribution 'stable'
   components %w(main)

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -37,7 +37,7 @@ describe 'chrome_test::default' do
     end
 
     it 'adds repo' do
-      expect(chef_run).to add_apt_repository('chrome')
+      expect(chef_run).to add_apt_repository('google-chrome')
     end
 
     it 'installs chrome' do


### PR DESCRIPTION
The chrome package will install an apt repo file as ``google-chrome`` which duplicates the one this cookbook installs as ``chrome``. While it doesn't technically break anything, it does create an annoying warning each time you run ``apt-get update``. This fixes that issue.