### PR TITLE
Use the machine key as opposed to processor

### DIFF
--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -3,7 +3,7 @@ apt_repository 'google-chrome' do
   distribution 'stable'
   components %w(main)
   key node['chrome']['apt_key']
-  arch 'amd64' if 'x86_64' == node['kernel']['processor']
+  arch 'amd64' if 'x86_64' == node['kernel']['machine']
   action :nothing
 end.run_action(:add)
 


### PR DESCRIPTION
Same convention as https://github.com/dhoer/chef-chrome/blob/master/recipes/msi.rb#L1. Seems to be a standard for `ohai` as well.