### PR TITLE
default apt arch to amd64 since that is all the default repository pr…

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,8 @@ default['chrome']['master_preferences_mac'] = '/Library/Google/Google Chrome Mas
 default['chrome']['master_preferences_linux'] = '/opt/google/chrome/master_preferences'
 
 default['chrome']['apt_uri'] = 'http://dl.google.com/linux/chrome/deb'
+default['chrome']['apt_arch'] = 'amd64'
+
 default['chrome']['apt_key'] = 'https://dl-ssl.google.com/linux/linux_signing_key.pub'
 default['chrome']['dmg_source'] = 'https://dl-ssl.google.com/chrome/mac/stable/GGRM/googlechrome.dmg'
 default['chrome']['dmg_checksum'] = nil

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -1,4 +1,5 @@
 apt_repository 'google-chrome' do
+  arch node['chrome']['apt_arch']
   uri node['chrome']['apt_uri']
   distribution 'stable'
   components %w(main)


### PR DESCRIPTION
…ovides

This fixes an issue with apt-get update on installations configured to fetch i386 arch too:

> STDERR: W: Failed to fetch http://dl.google.com/linux/chrome/deb/dists/stable/Release  Unable to find expected entry 'main/binary-i386/Packages' in Release file (Wrong sources.list entry or malformed file)