### PR TITLE
Don't install chrome if already installed

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -14,6 +14,7 @@ private
 def chrome_windows_version
   master_preferences_path = node['chrome']['master_preferences_windows']
   install_dir = master_preferences_path.slice(0, master_preferences_path.rindex('\\'))
+  return nil unless ::File.directory?(install_dir)
   entries = ::Dir.entries(install_dir).reverse # chefspec hint: see spec/unit/version_spec.rb
   entries.each do |filename|
     return filename if filename[/^[\d|.].*$/]

--- a/recipes/msi.rb
+++ b/recipes/msi.rb
@@ -2,5 +2,5 @@ chrome64 = node['kernel']['machine'] == 'x86_64' && !node['chrome']['32bit_only'
 windows_package 'Google Chrome' do
   source chrome64 ? node['chrome']['msi_64'] : node['chrome']['msi']
   action :nothing
-  only_if { (chrome_windows_version).empty? }
+  only_if { chrome_windows_version.nil? }
 end.run_action(:install)

--- a/recipes/msi.rb
+++ b/recipes/msi.rb
@@ -2,4 +2,5 @@ chrome64 = node['kernel']['machine'] == 'x86_64' && !node['chrome']['32bit_only'
 windows_package 'Google Chrome' do
   source chrome64 ? node['chrome']['msi_64'] : node['chrome']['msi']
   action :nothing
+  only_if { (chrome_windows_version).empty? }
 end.run_action(:install)


### PR DESCRIPTION
This was causing an error for us because Chrome had auto-updated to a newer version than that supported by this cookbook. That prevented us running another cookbook that has a dependency on chrome.