### PR TITLE
All Deb Package for Stable,Beta,Unstable are in the stable uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.1 2017-05-17
+
+- All Deb Package for Stable,Beta,Unstable are in the stable uri
+
 ## 4.0.0 2017-04-11
 
 - Rename master_preferences' params attribute to parameters to be Chef 13 compatible

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures Chrome browser'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/dhoer/chef-chrome'
 issues_url 'https://github.com/dhoer/chef-chrome/issues'
-version '4.0.0'
+version '4.0.1'
 
 chef_version '>= 12.14'
 

--- a/recipes/apt.rb
+++ b/recipes/apt.rb
@@ -1,7 +1,7 @@
 apt_repository 'google-chrome' do
   arch node['chrome']['apt_arch']
   uri node['chrome']['apt_uri']
-  distribution node['chrome']['track']
+  distribution 'stable'
   components %w(main)
   key node['chrome']['apt_key']
   action :nothing


### PR DESCRIPTION
Here a quick fix.

Package are all available in the same same URI 
http://dl.google.com/linux/chrome/deb/dists/stable/main/binary-amd64/Packages

Package: google-chrome-stable
Version: 58.0.3029.110-1

Package: google-chrome-beta
Version: 59.0.3071.47-1

Package: google-chrome-unstable
Version: 60.0.3100.0-1

